### PR TITLE
Block reserved time slots in booking form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,7 @@ pm run init-db is required after merging.
 
 ## Environment & Data Notes
 Set PORT, FACILITY_TZ, or other overrides via process env vars in your shell or a .env file (not committed). Remember the JSON-backed store under data/ is single-user; avoid deploying it as-is to multi-user environments, and add locking or move to a real database if concurrent writes become an issue.
+
+## Dominio funcional
+- El producto gestiona reservas de pistas individuales. Evita copys que hablen de "Pádel Los Nogales" o indiquen un número fijo de pistas disponibles; el contenido genérico debe referirse a la selección de una pista concreta.
+- En la vista de cliente no debe aparecer un acceso visible a la parte de administración. Mantén cada flujo separado hasta que se definan requerimientos adicionales.

--- a/public/index.html
+++ b/public/index.html
@@ -3,61 +3,109 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Reservas - Polideportivo (Cliente)</title>
+  <title>Gestión de reservas de pistas</title>
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body id="page-client">
-  <header>
-    <h1>Reservas - Polideportivo</h1>
-    <nav>
-      <a href="/index.html">Cliente</a> |
-      <a href="/admin.html">Admin</a>
-    </nav>
-  </header>
-
-  <main>
-    <section class="controls">
-      <label>Pista:
-        <select id="pistaSelect"></select>
-      </label>
-      <label>Fecha:
-        <input type="date" id="dateInput" />
-      </label>
-      <button id="btnLoad">Cargar</button>
-    </section>
-
-    <section id="calendarSection">
-      <!-- Calendario simple abajo -->
-    </section>
-
-    <section id="formReserve" class="card">
-      <h3>Reservar</h3>
-      <form id="reserveForm">
-        <input type="hidden" id="resPista" />
-        <label>Nombre: <input type="text" id="resName" required /></label>
-        <label>Telefono: <input type="text" id="resPhone" /></label>
-        <label>Email: <input type="email" id="resEmail" /></label>
-        <label>Hora inicio:
-          <select id="resStart" required></select>
-        </label>
-        <label>Duracion (min):
-          <select id="resDuration">
-            <option value="30">30</option>
-            <option value="60" selected>60</option>
-            <option value="90">90</option>
-          </select>
-        </label>
-        <div>
-          <button type="submit">Reservar</button>
+  <div class="app-wrapper">
+    <header class="hero">
+      <div class="hero__image" aria-hidden="true"></div>
+      <div class="hero__overlay"></div>
+      <div class="hero__content">
+        <div class="hero__back" aria-hidden="true">‹</div>
+        <div class="hero__info">
+          <div class="hero__badge">Agenda</div>
+          <h1>Reserva tu pista deportiva</h1>
+          <p class="hero__address">Consulta la disponibilidad y confirma reservas para cada pista.</p>
+          <div class="hero__tags">
+            <span class="hero__tag">Selecciona pista y horario</span>
+            <span class="hero__tag">Confirmación inmediata</span>
+          </div>
         </div>
-      </form>
-      <div id="formMsg"></div>
-    </section>
-  </main>
+        <nav class="hero__nav">
+          <a href="/index.html" class="hero__nav-link is-active">Reservas</a>
+        </nav>
+      </div>
+    </header>
 
-  <footer>
-    Zona horaria: Europe/Madrid - Prototipo minimalista
-  </footer>
+    <main class="main-grid">
+      <section class="booking card">
+        <div class="booking__controls">
+          <label class="field">
+            <span class="field__label">Pista</span>
+            <select id="pistaSelect" class="field__control"></select>
+          </label>
+          <label class="field field--hidden">
+            <span class="field__label">Fecha</span>
+            <input type="date" id="dateInput" class="field__control" />
+          </label>
+          <button id="btnLoad" class="ghost-btn" type="button">Actualizar</button>
+        </div>
+
+        <div class="day-strip">
+          <button id="btnPrevDays" class="day-strip__nav" type="button" aria-label="Días anteriores">‹</button>
+          <div id="dayStrip" class="day-strip__list"></div>
+          <button id="btnNextDays" class="day-strip__nav" type="button" aria-label="Días siguientes">›</button>
+        </div>
+
+        <div class="availability-toggle">
+          <label class="switch">
+            <input type="checkbox" id="onlyAvailableToggle" />
+            <span class="switch__slider" aria-hidden="true"></span>
+          </label>
+          <span class="availability-toggle__label">Mostrar solo las horas disponibles</span>
+        </div>
+
+        <section id="calendarSection" class="calendar">
+          <div class="calendar__header">
+            <h2 id="calendarTitle"></h2>
+            <p id="calendarSubtitle"></p>
+          </div>
+          <div id="hoursGrid" class="hours-grid"></div>
+        </section>
+      </section>
+
+      <section id="formReserve" class="card reservation">
+        <h3>Completa tu reserva</h3>
+        <form id="reserveForm" class="form">
+          <input type="hidden" id="resPista" />
+          <label class="field">
+            <span class="field__label">Nombre</span>
+            <input type="text" id="resName" required class="field__control" />
+          </label>
+          <label class="field">
+            <span class="field__label">Teléfono</span>
+            <input type="text" id="resPhone" class="field__control" />
+          </label>
+          <label class="field">
+            <span class="field__label">Email</span>
+            <input type="email" id="resEmail" class="field__control" />
+          </label>
+          <label class="field field--hidden">
+            <span class="field__label">Hora inicio</span>
+            <select id="resStart" required class="field__control"></select>
+          </label>
+          <div class="selected-hour" id="selectedHourDisplay">Selecciona una hora disponible en el calendario</div>
+          <label class="field">
+            <span class="field__label">Duración (min)</span>
+            <select id="resDuration" class="field__control">
+              <option value="30">30</option>
+              <option value="60" selected>60</option>
+              <option value="90">90</option>
+            </select>
+          </label>
+          <div class="form__actions">
+            <button type="submit" class="primary-btn">Reservar</button>
+          </div>
+        </form>
+        <div id="formMsg"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      Zona horaria: Europe/Madrid · Prototipo de reservas
+    </footer>
+  </div>
 
   <script src="/app.js"></script>
 </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,23 +1,527 @@
 /* styles.css */
 :root {
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
-    color: #111;
-    background: #f6f7f9;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: #0f172a;
+  background: #edf2fb;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #edf2fb;
+  color: #0f172a;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.card {
+  background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+  padding: 24px;
+}
+
+.app-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero {
+  position: relative;
+  min-height: 260px;
+  padding: 32px 24px 96px;
+  overflow: hidden;
+  color: #fff;
+}
+
+.hero__image {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, rgba(56, 189, 248, 0.65), rgba(15, 23, 42, 0.85)),
+    linear-gradient(120deg, rgba(14, 165, 233, 0.4), rgba(45, 212, 191, 0.2));
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85) 0%, rgba(15, 118, 110, 0.65) 100%);
+}
+
+.hero__content {
+  position: relative;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hero__back {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 28px;
+}
+
+.hero__info h1 {
+  margin: 8px 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero__address {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.9;
+}
+
+.hero__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.hero__tag {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+  font-size: 0.85rem;
+}
+
+.hero__nav {
+  display: flex;
+  gap: 18px;
+}
+
+.hero__nav-link {
+  position: relative;
+  font-weight: 600;
+  opacity: 0.8;
+}
+
+.hero__nav-link.is-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 3px;
+  background: #22d3ee;
+  border-radius: 999px;
+}
+
+.hero__nav-link.is-active {
+  opacity: 1;
+}
+
+.main-grid {
+  flex: 1;
+  margin-top: -72px;
+  padding: 0 16px 48px;
+  display: grid;
+  gap: 24px;
+}
+
+.booking__controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.field__label {
+  font-weight: 600;
+}
+
+.field__control {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #f8fbff;
+  font-size: 1rem;
+  color: inherit;
+}
+
+.field--hidden {
+  display: none !important;
+}
+
+.ghost-btn {
+  padding: 12px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+}
+
+.day-strip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.day-strip__nav {
+  width: 38px;
+  height: 60px;
+  border-radius: 16px;
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  font-size: 24px;
+}
+
+.day-strip__list {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(78px, 1fr);
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: none;
+}
+
+.day-strip__list::-webkit-scrollbar {
+  display: none;
+}
+
+.day-pill {
+  border: none;
+  border-radius: 20px;
+  padding: 10px 12px;
+  background: #f1f5f9;
+  color: #0f172a;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 78px;
+  transition: transform 0.2s, background 0.2s;
+}
+
+.day-pill__dow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.day-pill__day {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.day-pill__month {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.day-pill.is-active {
+  background: #0ea5e9;
+  color: #fff;
+  transform: translateY(-4px);
+}
+
+.day-pill.is-active .day-pill__dow,
+.day-pill.is-active .day-pill__month {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.availability-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.switch {
+  position: relative;
+  width: 48px;
+  height: 26px;
+  display: inline-block;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch__slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: rgba(148, 163, 184, 0.6);
+  border-radius: 999px;
+  transition: background 0.2s;
+}
+
+.switch__slider::before {
+  content: "";
+  position: absolute;
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  top: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.switch input:checked + .switch__slider {
+  background: #0ea5e9;
+}
+
+.switch input:checked + .switch__slider::before {
+  transform: translateX(22px);
+}
+
+.calendar {
+  border-radius: 20px;
+  background: #f8fbff;
+  padding: 20px;
+}
+
+.calendar__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.calendar__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.calendar__header p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.hours-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+}
+
+.hours-grid__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 24px 12px;
+  border-radius: 16px;
+  background: rgba(148, 163, 184, 0.15);
+  color: #475569;
+  font-weight: 600;
+}
+
+.slot-btn {
+  border: none;
+  border-radius: 16px;
+  padding: 14px 16px;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-weight: 600;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.slot-btn:hover:not(:disabled) {
+  background: #0ea5e9;
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.slot-btn.is-selected {
+  background: #0ea5e9;
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.25);
+}
+
+.slot-btn.is-reserved {
+  background: rgba(148, 163, 184, 0.35);
+  color: #475569;
+  cursor: not-allowed;
+}
+
+.selected-hour {
+  margin: 16px 0;
+  padding: 12px 16px;
+  background: #f1f5f9;
+  border-radius: 14px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.selected-hour.is-active {
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(14, 165, 233, 0.4);
+  color: #0369a1;
+}
+
+.form {
+  display: grid;
+  gap: 16px;
+}
+
+select option:disabled,
+select option.is-reserved {
+  color: #94a3b8;
+  background-color: #e2e8f0;
+}
+
+.primary-btn {
+  padding: 14px 18px;
+  border-radius: 16px;
+  border: none;
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.footer {
+  padding: 24px 16px 32px;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+#formMsg {
+  margin-top: 12px;
+  font-weight: 600;
+}
+
+#pistaMsg {
+  margin-top: 8px;
+  font-weight: 600;
+}
+
+/* Admin layout keeps the classic look */
+body#page-admin header {
+  background: #0b5;
+  padding: 12px 16px;
+  color: #003;
+}
+
+body#page-admin header h1 {
+  margin: 0 0 6px;
+  font-size: 1.2rem;
+}
+
+body#page-admin nav a {
+  color: #003;
+  text-decoration: none;
+  margin-right: 8px;
+  font-size: 0.95rem;
+}
+
+body#page-admin main {
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+}
+
+body#page-admin footer {
+  padding: 12px 16px;
+  font-size: 0.85rem;
+  color: #333;
+  background: #fff;
+  border-top: 1px solid #eee;
+  margin-top: 16px;
+}
+
+body#page-admin label {
+  display: inline-flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  margin-right: 8px;
+}
+
+body#page-admin input,
+body#page-admin select,
+body#page-admin button {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid #ddd;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+@media (min-width: 960px) {
+  .main-grid {
+    grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
+    align-items: start;
   }
-  body { margin: 0; padding: 0; }
-  header { background: #0b5; padding: 12px 16px; color: #003; }
-  header h1 { margin: 0 0 6px 0; font-size: 1.2rem; }
-  nav a { color: #003; text-decoration: none; margin-right: 8px; font-size: .95rem; }
-  main { padding: 16px; display: grid; gap: 16px; }
-  .controls { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-  .card { background: white; padding:12px; border-radius:8px; box-shadow: 0 1px 4px rgba(0,0,0,.06); }
-  #calendarSection { min-height: 220px; }
-  .slot { padding:6px; border-bottom:1px solid #eee; display:flex; justify-content:space-between; align-items:center; }
-  .reserved { background:#ffd; border-left:4px solid #f99; padding-left:8px; }
-  .available { background:#f7fff7; }
-  footer { padding: 12px 16px; font-size: .85rem; color:#333; background: #fff; border-top: 1px solid #eee; margin-top: 16px;}
-  label { display:inline-flex; flex-direction:column; font-size:.9rem; margin-right:8px; }
-  input, select, button { padding:6px 8px; border-radius:6px; border:1px solid #ddd; font-size:.95rem; }
-  button { cursor:pointer; }
-  #formMsg, #pistaMsg { margin-top:8px; color: #c00; }
-  
+
+  .hero {
+    padding-bottom: 120px;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 24px 16px 88px;
+  }
+
+  .hero__info h1 {
+    font-size: 1.6rem;
+  }
+
+  .day-strip__nav {
+    height: 52px;
+  }
+
+  .slot-btn {
+    padding: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- block reserved hours from being selected by disabling hour buttons and the start-time dropdown whenever existing reservas overlap
- sync manual dropdown selection with the grid highlight so both controls reflect the chosen slot
- style disabled options in the selector to visually communicate unavailable hours

## Testing
- not run (not requested)

