### PR TITLE
Fix client day strip date formatting

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -92,7 +92,10 @@ function addDays(date, amount) {
 }
 
 function toISODate(date) {
-  return date.toISOString().slice(0, 10);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 function isSameDay(a, b) {


### PR DESCRIPTION
## Summary
- format calendar day values using the browser's local date components
- prevent the day selector from skipping dates such as 10 October in positive timezones

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e27a10efd0832da61924157be13f5a