### PR TITLE
Ensure main grid stacks on narrow viewports

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -153,6 +153,7 @@ button {
   margin-top: -72px;
   padding: 0 16px 48px;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 24px;
 }
 


### PR DESCRIPTION
## Summary
- force the main grid to render as a single column by default to prevent horizontal scrolling
- preserve the desktop breakpoint for the two-column layout at widths ≥960px

## Testing
- viewport 480x800 screenshot and scroll width check

------
https://chatgpt.com/codex/tasks/task_e_68e286736b44832dabb7ed24a8a97925