### PR TITLE
Ensure admin cards stack on narrow viewports

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -474,6 +474,7 @@ body#page-admin main {
   padding: 16px;
   display: grid;
   gap: 16px;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 body#page-admin footer {
@@ -503,6 +504,10 @@ body#page-admin button {
 }
 
 @media (min-width: 960px) {
+  body#page-admin main {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .main-grid {
     grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
     align-items: start;


### PR DESCRIPTION
## Summary
- set the admin main grid to single-column by default so cards stack on small screens
- add a 960px breakpoint to restore a two-column layout when there is space

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e2867cf078832db1b493b239116c2c