### PR TITLE
Adjust day strip navigation responsiveness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@ pm run init-db is required after merging.
 Set PORT, FACILITY_TZ, or other overrides via process env vars in your shell or a .env file (not committed). Remember the JSON-backed store under data/ is single-user; avoid deploying it as-is to multi-user environments, and add locking or move to a real database if concurrent writes become an issue.
 
 ## Dominio funcional
-- Por un lado está la app cliente, en index.hmtl. 
+- Por un lado está la app cliente, en index.hmtl.
 esta app es para que los usuarios puedan seleccionar distintas pistas para revervar. Una vez en la pista seleccionada, podrán elegir una hora y completar sus datos para reservar.
 - Por otro lado, la app admin es para gestionar las pistas y las reservas, pudiendo eliminarlas
+
+## Notas de navegación de días (Cliente)
+- El cliente utiliza `renderDayStrip` para pintar tiras de 7 días consecutivos a partir de `stripStartDate`. El rango visible se mantiene entre `stripStartDate` y `stripStartDate + 6` días.
+- La función auxiliar `getDayNavigationStep()` (declarada dentro de `initClient` en `public/app.js`) decide cómo avanzan los botones de navegación:
+  - Devuelve `1` cuando `window.matchMedia('(max-width: 600px)')` es verdadero para que, en móviles, los botones avancen o retrocedan día a día manteniendo la continuidad visual.
+  - Devuelve `7` en caso contrario para conservar los saltos semanales en viewport amplios.
+- Los controladores `btnPrevDays` y `btnNextDays` actualizan `stripStartDate` y `selectedDate` usando el paso dinámico, claman las fechas con `clampToToday`, y ajustan `selectedDate` al rango visible (`stripStartDate` a `stripStartDate + 6`). Después de mover el rango se invocan `renderDayStrip`, `clearSelectedHour` y `loadCalendar` para refrescar la UI.

--- a/public/app.js
+++ b/public/app.js
@@ -150,6 +150,10 @@ async function initClient() {
   let selectedDate = today;
   let selectedHour = '';
 
+  function getDayNavigationStep() {
+    return window.matchMedia('(max-width: 600px)').matches ? 1 : 7;
+  }
+
   populateStartOptions(resStartSelect);
   resStartSelect.selectedIndex = -1;
 
@@ -241,10 +245,15 @@ async function initClient() {
   });
 
   btnPrevDays?.addEventListener('click', () => {
-    stripStartDate = clampToToday(facilityStartOfDay(addDays(stripStartDate, -7)));
-    selectedDate = clampToToday(facilityStartOfDay(addDays(selectedDate, -7)));
+    const step = getDayNavigationStep();
+    stripStartDate = clampToToday(facilityStartOfDay(addDays(stripStartDate, -step)));
+    selectedDate = facilityStartOfDay(addDays(selectedDate, -step));
+    selectedDate = clampToToday(selectedDate);
+    const rangeEnd = addDays(stripStartDate, 6);
     if (selectedDate < stripStartDate) {
       selectedDate = stripStartDate;
+    } else if (selectedDate > rangeEnd) {
+      selectedDate = rangeEnd;
     }
     syncDateInput();
     renderDayStrip();
@@ -252,9 +261,14 @@ async function initClient() {
     loadCalendar();
   });
   btnNextDays?.addEventListener('click', () => {
-    stripStartDate = facilityStartOfDay(addDays(stripStartDate, 7));
-    selectedDate = facilityStartOfDay(addDays(selectedDate, 7));
-    if (selectedDate < stripStartDate) {
+    const step = getDayNavigationStep();
+    stripStartDate = clampToToday(facilityStartOfDay(addDays(stripStartDate, step)));
+    selectedDate = facilityStartOfDay(addDays(selectedDate, step));
+    selectedDate = clampToToday(selectedDate);
+    const rangeEnd = addDays(stripStartDate, 6);
+    if (selectedDate > rangeEnd) {
+      selectedDate = rangeEnd;
+    } else if (selectedDate < stripStartDate) {
       selectedDate = stripStartDate;
     }
     syncDateInput();


### PR DESCRIPTION
## Summary
- add a responsive helper in the client to determine day navigation step based on viewport width
- update previous and next controls to keep the selected day within the visible strip while reloading the view
- document the day strip navigation concepts in AGENTS.md for future reference

## Testing
- npm start
- manual viewport verification in mobile and desktop widths

------
https://chatgpt.com/codex/tasks/task_e_68e28c6f5d9c832da787ac4b270900ab