### PR TITLE
Remove hero back arrow from hero section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,6 @@
       <div class="hero__image" aria-hidden="true"></div>
       <div class="hero__overlay"></div>
       <div class="hero__content">
-        <div class="hero__back" aria-hidden="true">‹</div>
         <div class="hero__info">
           <div class="hero__badge">Agenda</div>
           <h1>Reserva tu pista deportiva</h1>

--- a/public/styles.css
+++ b/public/styles.css
@@ -69,17 +69,7 @@ button {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-}
-
-.hero__back {
-  width: 42px;
-  height: 42px;
-  display: grid;
-  place-items: center;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
-  font-size: 28px;
+  gap: 16px;
 }
 
 .hero__info h1 {


### PR DESCRIPTION
## Summary
- remove the decorative back arrow container from the hero content
- tighten the hero layout spacing so the Agenda badge starts at the top of the hero

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e290746cdc832d9192531b6c57997c