### PR TITLE
Adapt client booking flow for peluquería reservations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,15 @@ esta app es para que los usuarios puedan seleccionar distintas pistas para rever
   - Devuelve `1` cuando `window.matchMedia('(max-width: 600px)')` es verdadero para que, en móviles, los botones avancen o retrocedan día a día manteniendo la continuidad visual.
   - Devuelve `7` en caso contrario para conservar los saltos semanales en viewport amplios.
 - Los controladores `btnPrevDays` y `btnNextDays` actualizan `stripStartDate` y `selectedDate` usando el paso dinámico, claman las fechas con `clampToToday`, y ajustan `selectedDate` al rango visible (`stripStartDate` a `stripStartDate + 6`). Después de mover el rango se invocan `renderDayStrip`, `clearSelectedHour` y `loadCalendar` para refrescar la UI.
+
+## Rama pelu: análisis funcional y técnico
+- **Funcional**
+  - El flujo cliente se adapta a una única peluquería: el selector muestra una sola opción y los textos hablan de citas y servicios de peluquería.
+  - La parrilla de horarios ofrece bloques de 30 minutos desde las 16:00 hasta las 22:00, visibles tanto en el calendario como en el selector de hora de inicio.
+  - El formulario sustituye la duración libre por el campo "Tipo de corte" con tres servicios predefinidos (barba, corte, barba y corte) y valida que se elija uno antes de reservar.
+  - El mensaje de hora seleccionada y las etiquetas del calendario guían al usuario para elegir servicio + horario antes de confirmar la reserva.
+- **Técnico**
+  - Se centraliza la configuración del cliente en `CLIENT_CONFIG`, permitiendo redefinir rango horario, tamaño de bloque y catálogo de servicios mediante `window.__PELUQUERIA_CONFIG__`.
+  - Las funciones auxiliares `buildTimeSlots`, `normalizeServiceConfig` e `isStartTimeAvailableForService` calculan franjas dinámicas y comprueban la disponibilidad continua necesaria para cada servicio (p. ej. 90 minutos = 3 bloques).
+  - `loadCalendar` genera los botones de horario en dos pasos: primero calcula disponibilidad cruda por bloque y luego aplica las restricciones del servicio activo para habilitar/deshabilitar ranuras y filtrar el modo "solo disponibles".
+  - El selector de hora reutiliza `updateStartSelectAvailability` para marcar visualmente ranuras reservadas frente a ranuras insuficientes, manteniendo sincronizado el estado tras cada cambio de servicio o nueva reserva.

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Gestión de reservas de pistas</title>
+  <title>Gestión de reservas de peluquería</title>
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body id="page-client">
@@ -14,10 +14,10 @@
       <div class="hero__content">
         <div class="hero__info">
           <div class="hero__badge">Agenda</div>
-          <h1>Reserva tu pista deportiva</h1>
-          <p class="hero__address">Consulta la disponibilidad y confirma reservas para cada pista.</p>
+          <h1>Reserva tu cita de peluquería</h1>
+          <p class="hero__address">Consulta la disponibilidad y confirma tu visita a la peluquería.</p>
           <div class="hero__tags">
-            <span class="hero__tag">Selecciona pista y horario</span>
+            <span class="hero__tag">Elige servicio y horario</span>
             <span class="hero__tag">Confirmación inmediata</span>
           </div>
         </div>
@@ -31,7 +31,7 @@
       <section class="booking card">
         <div class="booking__controls">
           <label class="field">
-            <span class="field__label">Pista</span>
+            <span class="field__label">Peluquería</span>
             <select id="pistaSelect" class="field__control"></select>
           </label>
           <label class="field field--hidden">
@@ -84,14 +84,10 @@
             <span class="field__label">Hora inicio</span>
             <select id="resStart" required class="field__control"></select>
           </label>
-          <div class="selected-hour" id="selectedHourDisplay">Selecciona una hora disponible en el calendario</div>
+          <div class="selected-hour" id="selectedHourDisplay">Selecciona una hora disponible para tu servicio</div>
           <label class="field">
-            <span class="field__label">Duración (min)</span>
-            <select id="resDuration" class="field__control">
-              <option value="30">30</option>
-              <option value="60" selected>60</option>
-              <option value="90">90</option>
-            </select>
+            <span class="field__label">Tipo de corte</span>
+            <select id="resService" class="field__control"></select>
           </label>
           <div class="form__actions">
             <button type="submit" class="primary-btn">Reservar</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -383,6 +383,13 @@ button {
   cursor: not-allowed;
 }
 
+.slot-btn.is-unavailable {
+  background: rgba(148, 163, 184, 0.25);
+  color: #64748b;
+  cursor: not-allowed;
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+}
+
 .selected-hour {
   margin: 16px 0;
   padding: 12px 16px;
@@ -407,6 +414,12 @@ select option:disabled,
 select option.is-reserved {
   color: #94a3b8;
   background-color: #e2e8f0;
+}
+
+select option.is-unavailable {
+  color: #94a3b8;
+  background-color: #f8fafc;
+  font-style: italic;
 }
 
 .primary-btn {


### PR DESCRIPTION
## Summary
- update the public client copy to reference the peluquería experience and service selection
- configure the booking grid for 30-minute slots between 16:00 and 22:00 with a configurable services catalog
- adjust availability handling, styling, and documentation (AGENTS.md) to reflect the new peluquería flow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e292eb39e4832da156faed4c0e4e57