### PR TITLE
Add service type to reservations in admin view

### DIFF
--- a/db.js
+++ b/db.js
@@ -72,7 +72,7 @@ module.exports = {
     const db = await readDB();
     return (db.reservas || []).filter(r => r.pistaId === pistaId);
   },
-  async addReserva({ pistaId, startISO, endISO, nombre, telefono, email, date, startTime, durationMin, timezone }) {
+  async addReserva({ pistaId, startISO, endISO, nombre, telefono, email, servicioId, tipoCorte, date, startTime, durationMin, timezone }) {
     const db = await readDB();
     db.reservas = db.reservas || [];
     db.pistas = db.pistas || [];
@@ -99,6 +99,8 @@ module.exports = {
     const reserva = {
       id: makeId('RES_'),
       pistaId,
+      servicioId: servicioId || null,
+      tipoCorte: tipoCorte || null,
       date,
       startTime,
       durationMin,

--- a/index.js
+++ b/index.js
@@ -164,11 +164,17 @@ app.post('/api/reservas', async (req, res) => {
 
   try {
 
-    const { pistaId, date, startTime, durationMin, nombre, telefono, email } = req.body;
+    const { pistaId, date, startTime, durationMin, nombre, telefono, email, servicioId, tipoCorte } = req.body;
 
     if (!pistaId || !date || !startTime || !nombre) {
 
       return res.status(400).json({ error: 'Falta campo requerido (pistaId/date/startTime/nombre).' });
+
+    }
+
+    if (!servicioId || typeof servicioId !== 'string' || !servicioId.trim()) {
+
+      return res.status(400).json({ error: 'Falta seleccionar el tipo de servicio.' });
 
     }
 
@@ -223,6 +229,10 @@ app.post('/api/reservas', async (req, res) => {
       telefono,
 
       email,
+
+      servicioId: servicioId.trim(),
+
+      tipoCorte: typeof tipoCorte === 'string' && tipoCorte.trim() ? tipoCorte.trim() : servicioId.trim(),
 
       date,
 

--- a/public/app.js
+++ b/public/app.js
@@ -750,12 +750,16 @@ async function initAdmin() {
       return;
     }
     const container = document.createElement('div');
-    container.innerHTML = reservas.map(r => `<div class="card" style="margin-bottom:8px;">
+    container.innerHTML = reservas.map(r => {
+      const serviceLabel = r.tipoCorte || r.servicioId || '-';
+      return `<div class="card" style="margin-bottom:8px;">
       <div><strong>${r.nombre}</strong> - ${r.pistaId}</div>
+      <div>Servicio: ${serviceLabel}</div>
       <div>${formatFacilityDateTime(r.start)} - ${formatFacilityDateTime(r.end)}</div>
       <div>Email: ${r.email || '-'} Tel: ${r.telefono || '-'}</div>
       <div style="margin-top:6px;"><button data-id="${r.id}" class="delBtn">Eliminar</button></div>
-    </div>`).join('');
+    </div>`;
+    }).join('');
     reservasList.innerHTML = '';
     reservasList.appendChild(container);
 


### PR DESCRIPTION
## Summary
- store the selected service identifiers and labels when creating reservations
- expose the stored service information to the admin reservation list UI

## Testing
- npm run init-db

------
https://chatgpt.com/codex/tasks/task_e_68e297b0decc832d9ecd801fd69c7a58