### PR TITLE
Adjust calendar slot colors for availability and reservations

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -359,7 +359,7 @@ button {
   border: none;
   border-radius: 16px;
   padding: 14px 16px;
-  background: #e2e8f0;
+  background: rgba(34, 197, 94, 0.16);
   color: #0f172a;
   font-weight: 600;
   transition: background 0.2s, transform 0.2s;
@@ -378,8 +378,8 @@ button {
 }
 
 .slot-btn.is-reserved {
-  background: rgba(148, 163, 184, 0.35);
-  color: #475569;
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary
- update available slot background to a subtle translucent green
- shift reserved slots to a light translucent red to distinguish them from available times

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e562c8f748832d99c6f7fe74a01e6c