### PR TITLE
Improve email notification configuration resilience

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,10 +5,15 @@ ADMIN_PASS=secret
 # FORCE_ADMIN_AUTH=true
 
 # SMTP configuration for email notifications
+# EMAIL_NOTIFICATIONS_ENABLED=true
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_SECURE=false # usa true si el proveedor requiere TLS implicito (p.ej. puerto 465)
 # SMTP_USER=apikey
 # SMTP_PASS=secret
+# SMTP_CONNECTION_TIMEOUT=10000
+# SMTP_GREETING_TIMEOUT=10000
+# SMTP_SOCKET_TIMEOUT=10000
+# SMTP_ALLOW_INVALID_CERTS=false
 # MAIL_FROM="Reservas <no-reply@example.com>"
 


### PR DESCRIPTION
## Summary
- allow disabling outgoing emails and tuning SMTP timeouts via environment variables to avoid hangs in managed hosts
- harden the email transport by resetting the cached transporter on connection errors
- document the new notification controls inside env.example for deployment configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5728472d4832dba95ff50a8358fcc