### PR TITLE
Handle SIGTERM gracefully in server entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -771,7 +771,26 @@ function startServer(port = PORT) {
 
 if (require.main === module) {
 
-  startServer();
+  const server = startServer();
+
+  let shuttingDown = false;
+
+  function gracefulShutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (NODE_ENV !== 'test') {
+      console.log(`Recibida señal ${signal}, cerrando servidor...`);
+    }
+    server.close(() => {
+      process.exit(0);
+    });
+    setTimeout(() => {
+      process.exit(0);
+    }, 5000).unref();
+  }
+
+  process.once('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  process.once('SIGINT', () => gracefulShutdown('SIGINT'));
 
 }
 


### PR DESCRIPTION
## Summary
- add graceful shutdown logic when the server receives termination signals so Railway stops cleanly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e579008790832d8433c8116bc1ac91