### PR TITLE
Require contact details before creating reservations

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -427,6 +427,11 @@ async function initClient() {
       return;
     }
 
+    if (typeof reserveForm.reportValidity === 'function' && !reserveForm.reportValidity()) {
+      formMsg.textContent = 'Rellena los campos obligatorios';
+      return;
+    }
+
     const pistaId = resPista.value;
     const name = document.getElementById('resName').value.trim();
     const phone = document.getElementById('resPhone').value.trim();
@@ -437,7 +442,7 @@ async function initClient() {
     const tipoCorte = getServiceLabel(serviceId);
     const date = dateInput.value;
 
-    if (!pistaId || !name || !startTime || !date || !serviceId || !Number.isFinite(durationMin)) {
+    if (!pistaId || !name || !phone || !email || !startTime || !date || !serviceId || !Number.isFinite(durationMin)) {
       formMsg.textContent = 'Rellena los campos obligatorios';
       return;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -74,11 +74,11 @@
           </label>
           <label class="field">
             <span class="field__label">Teléfono</span>
-            <input type="text" id="resPhone" class="field__control" />
+            <input type="text" id="resPhone" required class="field__control" />
           </label>
           <label class="field">
             <span class="field__label">Email</span>
-            <input type="email" id="resEmail" class="field__control" />
+            <input type="email" id="resEmail" required class="field__control" />
           </label>
           <label class="field field--hidden">
             <span class="field__label">Hora inicio</span>


### PR DESCRIPTION
## Summary
- mark the phone and email fields as required in the reservation form
- block reservation submission until required contact details are provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e57b0d9598832db87f1e09e2be33d9