### PR TITLE
Bind server to configurable host

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 const ADMIN_AUTH_ENABLED = Boolean(ADMIN_USER && ADMIN_PASS && (NODE_ENV === 'production' || FORCE_ADMIN_AUTH));
 
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '0.0.0.0';
 
 const FACILITY_TZ = 'Europe/Madrid';
 
@@ -749,9 +750,9 @@ app.get('*', (req, res) => {
 
 });
 
-function startServer(port = PORT) {
+function startServer(port = PORT, host = HOST) {
 
-  const server = app.listen(port, () => {
+  const server = app.listen(port, host, () => {
 
     if (NODE_ENV === 'test') return;
 
@@ -759,9 +760,17 @@ function startServer(port = PORT) {
 
     const actualPort = typeof address === 'object' && address ? address.port : port;
 
-    console.log(`Servidor arrancado en http://localhost:${actualPort}`);
+    const actualHost = typeof address === 'object' && address && address.address
 
-    console.log('Cliente disponible en: http://localhost:' + actualPort + '/index.html');
+      ? address.address
+
+      : host;
+
+    const publicHost = actualHost === '::' ? 'localhost' : actualHost;
+
+    console.log(`Servidor arrancado en http://${publicHost}:${actualPort}`);
+
+    console.log('Cliente disponible en: http://' + publicHost + ':' + actualPort + '/index.html');
 
   });
 


### PR DESCRIPTION
## Summary
- allow overriding the Express listen host via a HOST environment variable so deployments bind to 0.0.0.0 by default
- update startup logging to reflect the resolved host and port for easier diagnostics on managed platforms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e58430316c832dab1c4c48249be709