### PR TITLE
Fix timezone offset parsing for booking availability

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ function getTimeZoneOffsetMinutes(date, timeZone) {
 
   if (!tzPart) return 0;
 
-  const match = tzPart.value.match(/GMT([+-]\d{2})(?::?(\d{2}))?/);
+  const match = tzPart.value.match(/GMT([+-]\d{1,2})(?::?(\d{2}))?/);
 
   if (!match) return 0;
 

--- a/public/app.js
+++ b/public/app.js
@@ -45,7 +45,7 @@ function getTimeZoneOffsetMinutes(date, timeZone) {
   const parts = dtf.formatToParts(date);
   const tzPart = parts.find(part => part.type === 'timeZoneName');
   if (!tzPart) return 0;
-  const match = tzPart.value.match(/GMT([+-]\d{2})(?::?(\d{2}))?/);
+  const match = tzPart.value.match(/GMT([+-]\d{1,2})(?::?(\d{2}))?/);
   if (!match) return 0;
   const sign = match[1][0] === '-' ? -1 : 1;
   const hours = parseInt(match[1].slice(1), 10);


### PR DESCRIPTION
## Summary
- allow timezone offsets returned as GMT+H to be parsed correctly both in the client and API
- ensure slot availability is calculated with the proper offset so available hours render correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6c5a3b054832da9caab519c2cb575