### PR TITLE
Add logging for bulk deletion of past reservations

### DIFF
--- a/index.js
+++ b/index.js
@@ -758,6 +758,14 @@ app.delete('/api/admin/reservas/pasadas', async (req, res) => {
   const todayIso = getTodayIsoDate(FACILITY_TZ);
 
   const result = await db.deleteReservasBeforeDate(todayIso, FACILITY_TZ);
+  const removed = Number(result && result.removed) || 0;
+  if (removed > 0) {
+    console.info('[reservas] Reservas pasadas eliminadas', {
+      removed,
+      cutoffDate: todayIso,
+      facilityTz: FACILITY_TZ
+    });
+  }
 
   res.json(result);
 


### PR DESCRIPTION
## Summary
- log the bulk deletion of past reservations with contextual metadata when the admin endpoint removes entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f8068153fc832dbc57e6138b6ca15d