### PR TITLE
Log reservation conflict handling

### DIFF
--- a/db.js
+++ b/db.js
@@ -100,6 +100,13 @@ module.exports = {
         return newStart < r.end && newEnd > r.start;
       });
       if (conflicts.length > 0) {
+        console.warn('[reservas] Conflicto detectado al crear reserva', {
+          pistaId,
+          date,
+          startISO: newStart,
+          endISO: newEnd,
+          conflictIds: conflicts.map(r => r.id)
+        });
         const err = new Error('Conflicto de reserva (solapamiento) con otra reserva en la misma pista.');
         err.code = 'CONFLICT';
         throw err;

--- a/public/app.js
+++ b/public/app.js
@@ -492,7 +492,16 @@ async function initClient() {
       } else {
         const err = await resp.json().catch(() => ({}));
         if (resp.status === 409) {
-          formMsg.textContent = err?.error || 'La hora seleccionada ya no está disponible.';
+          const conflictMessage = err?.error || 'La hora seleccionada ya no está disponible.';
+          formMsg.textContent = conflictMessage;
+          console.warn('[reservas] Conflicto de reserva mostrado al usuario', {
+            pistaId,
+            date,
+            startTime,
+            durationMin,
+            servicioId: serviceId,
+            mensaje: conflictMessage
+          });
           await loadCalendar();
           clearSelectedHour();
         } else {


### PR DESCRIPTION
## Summary
- add server-side logging when a reservation conflict is detected before returning the 409 error
- log client-side context when the overlap conflict message is displayed to the user

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f8061771cc832d98d6826a5416d797