### PR TITLE
Validate reservation phone numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,30 @@ function isValidTime(time) {
 
 }
 
+function isValidPhone(phone) {
+
+  if (typeof phone !== 'string') return false;
+
+  const trimmed = phone.trim();
+
+  if (!trimmed) return false;
+
+  if (!/^\+?[0-9\s-]+$/.test(trimmed)) return false;
+
+  const digits = trimmed.replace(/\D/g, '');
+
+  if (digits.length < 9 || digits.length > 15) return false;
+
+  if (trimmed.includes('+') && !trimmed.startsWith('+')) return false;
+
+  const plusMatches = trimmed.match(/\+/g);
+
+  if (plusMatches && plusMatches.length > 1) return false;
+
+  return true;
+
+}
+
 function getTodayIsoDate(timeZone) {
 
   return new Intl.DateTimeFormat('en-CA', {
@@ -601,6 +625,18 @@ app.post('/api/reservas', async (req, res) => {
     if (!servicioIdValue) {
 
       return res.status(400).json({ error: 'Falta seleccionar el tipo de servicio.' });
+
+    }
+
+    if (typeof telefonoValue !== 'string' || !telefonoValue) {
+
+      return res.status(400).json({ error: 'El telefono es obligatorio.' });
+
+    }
+
+    if (!isValidPhone(telefonoValue)) {
+
+      return res.status(400).json({ error: 'Telefono invalido. Debe contener entre 9 y 15 digitos y puede incluir +, espacios o guiones.' });
 
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -86,6 +86,19 @@ function formatFacilityDateTime(iso) {
   }).format(new Date(iso));
 }
 
+function isValidPhone(phone) {
+  if (typeof phone !== 'string') return false;
+  const trimmed = phone.trim();
+  if (!trimmed) return false;
+  if (!/^\+?[0-9\s-]+$/.test(trimmed)) return false;
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length < 9 || digits.length > 15) return false;
+  if (trimmed.includes('+') && !trimmed.startsWith('+')) return false;
+  const plusMatches = trimmed.match(/\+/g);
+  if (plusMatches && plusMatches.length > 1) return false;
+  return true;
+}
+
 function buildClientConfig(rawConfig = {}) {
   const parsedStart = Number(rawConfig.startMinutes);
   const parsedEnd = Number(rawConfig.endMinutes);
@@ -442,7 +455,17 @@ async function initClient() {
     const tipoCorte = getServiceLabel(serviceId);
     const date = dateInput.value;
 
-    if (!pistaId || !name || !phone || !email || !startTime || !date || !serviceId || !Number.isFinite(durationMin)) {
+    if (!phone) {
+      formMsg.textContent = 'El telefono es obligatorio.';
+      return;
+    }
+
+    if (!isValidPhone(phone)) {
+      formMsg.textContent = 'Telefono invalido. Debe contener entre 9 y 15 digitos y puede incluir +, espacios o guiones.';
+      return;
+    }
+
+    if (!pistaId || !name || !email || !startTime || !date || !serviceId || !Number.isFinite(durationMin)) {
       formMsg.textContent = 'Rellena los campos obligatorios';
       return;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
           </label>
           <label class="field">
             <span class="field__label">Teléfono</span>
-            <input type="text" id="resPhone" required class="field__control" />
+            <input type="tel" id="resPhone" required class="field__control" inputmode="tel" pattern="^\+?(?:[\d][\s-]?){8,14}[\d]$" />
           </label>
           <label class="field">
             <span class="field__label">Email</span>

--- a/tests/reservation-flow.test.js
+++ b/tests/reservation-flow.test.js
@@ -88,6 +88,51 @@ test('reserva API persiste email admin y crea reservas', async (t) => {
   assert.ok(reservasBody.some(r => r.id === reservaBody.id));
 });
 
+test('reserva API rechaza telefono invalido', async (t) => {
+  const originalDb = cloneDeep(await db.raw());
+  const server = startServer(0);
+  await once(server, 'listening');
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(async () => {
+    await new Promise(resolve => server.close(resolve));
+    await db.saveRaw(originalDb);
+  });
+
+  let pistaId;
+  const pistas = await db.getPistas();
+  if (pistas.length === 0) {
+    const nuevaPista = await db.addPista({ nombre: 'Pista Test Telefono', descripcion: 'Temporal' });
+    pistaId = nuevaPista.id;
+  } else {
+    pistaId = pistas[0].id;
+  }
+  assert.ok(pistaId, 'Debe existir alguna pista para crear reservas');
+
+  const invalidPayload = {
+    pistaId,
+    date: '2099-12-31',
+    startTime: '11:00',
+    durationMin: 60,
+    nombre: 'Test User',
+    telefono: 'invalid-phone',
+    email: 'user@example.com',
+    servicioId: 'test-service'
+  };
+
+  const resp = await fetch(`${baseUrl}/api/reservas`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(invalidPayload)
+  });
+
+  assert.strictEqual(resp.status, 400);
+  const body = await resp.json();
+  assert.strictEqual(body?.error, 'Telefono invalido. Debe contener entre 9 y 15 digitos y puede incluir +, espacios o guiones.');
+});
+
 test('admin puede eliminar reservas pasadas', async (t) => {
   const originalDb = cloneDeep(await db.raw());
   const workingDb = cloneDeep(originalDb);


### PR DESCRIPTION
## Summary
- add a reusable phone validator on the server and reject empty or malformed numbers when creating reservas
- update the client form to use telephone-friendly input settings and surface phone validation errors
- extend the reservation flow tests to cover invalid phone submissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f909281ae0832d9b0669e1709d7e0e